### PR TITLE
Fix client 0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Skeleton of Jubatus Client Application in C++
 Requirements
 ------------
 
-* Jubatus 0.4.2+ (server & client headers)
+* Jubatus 0.5.0+ (server & client headers)
 * msgpack (with development headers)
 * jubatus-mpio (with development headers)
 * jubatus-msgpack-rpc (with development headers)

--- a/client.cpp
+++ b/client.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-const string HOST = "localhost";
+const string HOST = "127.0.0.1";
 const int    PORT = 9199;
 const string NAME = "";
 


### PR DESCRIPTION
Fix version number in README, and localhost to 127.0.0.1.

This PR is related to #2 , but `client.cpp` has been already for 0.5.0.
